### PR TITLE
Fix testing.cpp

### DIFF
--- a/testing.cpp
+++ b/testing.cpp
@@ -1,20 +1,9 @@
-// ConsoleApplication1.cpp : This file contains the 'main' function. Program execution begins and ends there.
-//
-
 #include <iostream>
 #include <processthreadsapi.h>
 #include <tchar.h>
 #include <windows.h>
 
-int main()
-{
-    STARTUPINFO si;
-    PROCESS_INFORMATION pi;
-    DoStuff();
-}
-
 void DoStuff() {
-    
     // Replace all this code by your payload
     STARTUPINFO si = { sizeof(STARTUPINFO) };
     PROCESS_INFORMATION pi;
@@ -23,17 +12,11 @@ void DoStuff() {
 
     CloseHandle(pi.hProcess);
     CloseHandle(pi.hThread);
-
-    return;
 }
 
-// Run program: Ctrl + F5 or Debug > Start Without Debugging menu
-// Debug program: F5 or Debug > Start Debugging menu
-
-// Tips for Getting Started: 
-//   1. Use the Solution Explorer window to add/manage files
-//   2. Use the Team Explorer window to connect to source control
-//   3. Use the Output window to see build output and other messages
-//   4. Use the Error List window to view errors
-//   5. Go to Project > Add New Item to create new code files, or Project > Add Existing Item to add existing code files to the project
-//   6. In the future, to open this project again, go to File > Open > Project and select the .sln file
+int main()
+{
+    STARTUPINFO si;
+    PROCESS_INFORMATION pi;
+    DoStuff();
+}


### PR DESCRIPTION
The function 'DoStuff' has to be declared before main in order to be used. I haven't changed the name, but it isn't according to C++ naming conventions; this is not a big problem, won't affect execution, but it will make your code look better. 

also, DoStuff was declared as void, but it had a return statement; it's not something that would break the code (it isn't a syntax error in C++) but it might be confusing for those reading the function.

I haven't tried to run it (I'm on a Mac right now) but let me know if there are any other issues when running this code.